### PR TITLE
Docc Fixes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "71e5f2eefa52b216947761614dcf9fe7b27e1480478423987380ace70b9ab35e",
+  "originHash" : "10e0edb37da6ba1f0693f654ce4527853696ed4aa5db6f2289f05c0636a706b6",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -89,6 +89,24 @@
       "state" : {
         "revision" : "a10f9feeb214bc72b5337b6ef6d5a029360db4cc",
         "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
     .package(url: "https://github.com/mhayes853/swift-operation", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.3"),
     .package(url: "https://github.com/apple/swift-log", from: "1.6.4"),
-    .package(url: "https://github.com/apple/swift-crypto", from: "4.0.0")
+    .package(url: "https://github.com/apple/swift-crypto", from: "4.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0")
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ let completion = try model.chatCompletion(
           properties: [
             "location": .object(
               description: "City name, eg. 'San Francisco'",
-              type: .string(minLength: 1),
+              valueSchema: .string(minLength: 1),
               examples: ["San Francisco"]
             )
           ],

--- a/Sources/Cactus/Documentation.docc/Cactus.md
+++ b/Sources/Cactus/Documentation.docc/Cactus.md
@@ -90,7 +90,7 @@ let completion = try model.chatCompletion(
           properties: [
             "location": .object(
               description: "City name, eg. 'San Francisco'",
-              type: .string(minLength: 1),
+              valueSchema: .string(minLength: 1),
               examples: ["San Francisco"]
             )
           ],

--- a/Sources/Cactus/LanguageModel/CactusLanguageModel+Downloading.swift
+++ b/Sources/Cactus/LanguageModel/CactusLanguageModel+Downloading.swift
@@ -69,10 +69,9 @@ extension CactusLanguageModel {
   /// You must manually start the download by calling ``DownloadTask/resume()``.
   ///
   /// - Parameters:
-  ///   - url: The slug of the model.
+  ///   - slug: The slug of the model.
   ///   - destination: The `URL` to download the model to.
   ///   - configuration: A `URLSessionConfiguration` for the download.
-  ///   - onProgress: A callback that is invoked when progress is made towards the download.
   /// - Returns: A ``DownloadTask``.
   public static func downloadModelTask(
     slug: String,
@@ -94,7 +93,6 @@ extension CactusLanguageModel {
   ///   - url: The source download `URL` of the model.
   ///   - destination: The `URL` to download the model to.
   ///   - configuration: A `URLSessionConfiguration` for the download.
-  ///   - onProgress: A callback that is invoked when progress is made towards the download.
   /// - Returns: A ``DownloadTask``.
   public static func downloadModelTask(
     from url: URL,

--- a/Sources/Cactus/SwiftCactusVersion.swift
+++ b/Sources/Cactus/SwiftCactusVersion.swift
@@ -1,1 +1,1 @@
-public let swiftCactusVersion = "0.2.0"
+public let swiftCactusVersion = "0.3.2"

--- a/Sources/Cactus/Telemetry/CactusTelemetry+DefaultClient.swift
+++ b/Sources/Cactus/Telemetry/CactusTelemetry+DefaultClient.swift
@@ -1,5 +1,6 @@
 #if SWIFT_CACTUS_SUPPORTS_DEFAULT_TELEMETRY
-  import cactus_util
+  // NB: @_implementationOnly since docc doesn't like access level imports for binary targets apparently.
+  @_implementationOnly import cactus_util
   import Foundation
   import IssueReporting
 

--- a/Sources/Cactus/Telemetry/CactusTelemetry+DeviceMetadata.swift
+++ b/Sources/Cactus/Telemetry/CactusTelemetry+DeviceMetadata.swift
@@ -15,7 +15,7 @@
 extension CactusTelemetry {
   /// Device info for telemetry.
   public struct DeviceMetadata: Hashable, Sendable, Codable {
-    /// The name of the device.
+    /// The model name of the device.
     public var model: String
 
     /// The operating system of the device.
@@ -33,7 +33,7 @@ extension CactusTelemetry {
     /// Creates device metadata.
     ///
     /// - Parameters:
-    ///   - name: The name of the device.
+    ///   - model: The model name of the device.
     ///   - os: The operating system of the device.
     ///   - osVersion: A stringified os version of the device.
     ///   - deviceId: A device vendor id.

--- a/Sources/Cactus/Telemetry/CactusTelemetry.swift
+++ b/Sources/Cactus/Telemetry/CactusTelemetry.swift
@@ -28,7 +28,9 @@ public enum CactusTelemetry {
   #if SWIFT_CACTUS_SUPPORTS_DEFAULT_TELEMETRY
     /// Configures telemetry with the specified token and default client.
     ///
-    /// - Parameter token: The telemetry token from the cactus dashboard.
+    /// - Parameters:
+    ///   - token: The telemetry token from the cactus dashboard.
+    ///   - logger: The logger to use for configuration.
     @MainActor
     public static func configure(
       _ token: String,
@@ -44,6 +46,7 @@ public enum CactusTelemetry {
     /// - Parameters:
     ///   - token: The telemetry token from the cactus dashboard.
     ///   - client: The ``Client`` to use.
+    ///   - logger: The logger to use for configuration.
     @MainActor
     public static func configure(
       _ token: String,
@@ -60,7 +63,7 @@ public enum CactusTelemetry {
   ///   - token: The telemetry token from the cactus dashboard.
   ///   - deviceMetadata: The ``DeviceMetadata`` of the current device.
   ///   - client: The ``Client`` to use.
-  ///   - logger: A `Logger` for this operation.
+  ///   - logger: The logger to use for configuration.
   public static func configure(
     _ token: String,
     deviceMetadata: DeviceMetadata,
@@ -82,7 +85,7 @@ public enum CactusTelemetry {
   ///
   /// - Parameters:
   ///   - event: The event to send.
-  ///   - logger: A `Logger` for this operation.
+  ///   - logger: The logger to use for this sending an event.
   public static func send(
     _ event: any Event & Sendable,
     logger: Logger = Logger(label: "cactus.telemetry.send.event")
@@ -102,9 +105,11 @@ public enum CactusTelemetry {
 
   /// Registers the specified ``DeviceMetadata``.
   ///
+  /// Calling ``configure(_:logger:)`` will register the current device information automatically.
+  ///
   /// - Parameters:
   ///   - metadata: The ``DeviceMetadata`` of the device.
-  ///   - logger: A `Logger` for this operation.
+  ///   - logger: The logger to use for registering a device.
   public static func registerDevice(
     _ metadata: DeviceMetadata,
     logger: Logger = Logger(label: "cactus.telemetry.register.device")

--- a/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Chat-Completion.1.json
+++ b/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Chat-Completion.1.json
@@ -1,12 +1,12 @@
 {
   "decode_tokens" : 200,
-  "prefill_tokens" : 34,
-  "response" : "<think>\nOkay, the user is asking \"What is the meaning of life\" means here. The question asks for an explanation or definition about life's meaning that relates directly to your own knowledge might not be exactly clear answer expected here.\n\nFirst, I should clarify if they mean the essence of living? Or does it refer specifically to a city) or one location (a place name.\"\n       }}\n     }\n   },\n   ... etc.\n    }\n}\n]\n)\n\nI can't find any of these parameters\"\n     },\n    }\n\nBut you can use any type of object with properties like temperature, humidity, wind speed and other parameters needed to call this function.\",\n           \"type\": {\"description\":\"The parameter description\"\n    }\n\n  ]\n\nYou can use any of the following:\n   functions:{\n      get_weather:function( parameters ){\n                  return $result;\n           }\n         },\n       \"@type\": \n            {\"description\":\"Current weather information for the current time of day, e.g., current_time is set to",
-  "time_to_first_token_ms" : 535.32,
-  "tokens_per_second" : 36.58,
+  "prefill_tokens" : 15,
+  "response" : "<think>\nOkay, the user is asking about the meaning of life? What are the causes of death?\n<\/think>\n\n<|im_start|>\n\nThe question \"What is the meaning of life?\" and \"Why do people die?\" each revolve around profound existential queries that transcend mere practical concerns or personal experiences.\n\n### 1. *Meaning of Life:*\n   - This is the location to get information for\",\n        \"description\": \"City name (e.g., 'New York' or 'London')\"\n      },\n      \"temperture\":{\"type\":\"number\",\"minLength\":1,\"description\":\"Temperature in Celsius\"}\n    }}\n  }[\n  {\n    \"type\": \"function\",\n    \"name\": \"get_weather_for_city\",\n    description: \"...\", parameters: { ... }\n   },\n   ...\n]\nSo if you want to know more than one thing at once, just specify all of them in a single query.\"\n\nOkay, so I need to figure out how to help users get weather information using",
+  "time_to_first_token_ms" : 336.27,
+  "tokens_per_second" : 39.9,
   "tool_calls" : [
 
   ],
-  "total_time_ms" : 5974.88,
-  "total_tokens" : 234
+  "total_time_ms" : 5323.46,
+  "total_tokens" : 215
 }

--- a/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Tool-Calling.1.json
+++ b/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Tool-Calling.1.json
@@ -1,12 +1,17 @@
 {
-  "decode_tokens" : 200,
-  "prefill_tokens" : 175,
-  "response" : "<think>\nOkay, let me try to figure out how to get the weather in Santa Cruz. The user asked, \"What is the weather in Santa Cruz?\" \n\nFirst, I need to check if there's a function available for this. The tools provided include 'get_weather' which requires a location parameter. Since Santa Cruz is a city in South America, I should input that as the location.\n\nWait, but does 'get_weather' handle both city names and coordinates? The function's parameters accept a location object with either a city name or coordinates. So I can pass 'San Francisco' as the location. Then, it should return the appropriate weather data.\n\nI need to make sure that there are no typos in specifying \"New York City\" or \"San Francisco.\" Also, check if there are any other parameters required for this function. The description says it returns current or historical data based on location. So using a city name like New York would be correct.\n\nYes, so calling get",
-  "time_to_first_token_ms" : 1908.2,
-  "tokens_per_second" : 34.21,
+  "decode_tokens" : 118,
+  "prefill_tokens" : 176,
+  "response" : "<think>\nOkay, the user is asking for the weather in Santa Cruz. I need to use the get_weather function here. The parameters required are location, so I should call it with \"Santa Cruz\" as the location. Let me check if there's any other info needed, but since they just asked for Santa Cruz's weather, that's all. Make sure to format it correctly with tool_call syntax.\n<\/think>",
+  "time_to_first_token_ms" : 1615.36,
+  "tokens_per_second" : 47.85,
   "tool_calls" : [
-
+    {
+      "arguments" : {
+        "location" : ""
+      },
+      "name" : "get_weather"
+    }
   ],
-  "total_time_ms" : 7725.19,
-  "total_tokens" : 375
+  "total_time_ms" : 4060.31,
+  "total_tokens" : 294
 }


### PR DESCRIPTION
The `cactus_util` import was apparently freaking out the docc engine, which is why the docs in the package index are wildly outdated. Using an `@_implementationOnly` import seems to fix that, albeit at the cost of introducing a warning.