### PR TITLE
DownloadTaskCreator

### DIFF
--- a/Sources/Cactus/LanguageModel/CactusLanguageModel+ChatMessage.swift
+++ b/Sources/Cactus/LanguageModel/CactusLanguageModel+ChatMessage.swift
@@ -5,10 +5,10 @@ extension CactusLanguageModel {
   public struct ChatMessage: Hashable, Sendable, Encodable {
     /// The ``Role`` of the message.
     public var role: Role
-    
+
     /// The message content.
     public var content: String
-    
+
     /// Creates a chat message.
     ///
     /// - Parameters:
@@ -31,12 +31,12 @@ extension CactusLanguageModel.ChatMessage {
     /// Use this role when providing instructions to the model
     /// (eg. `"You are a helpful assistant..."`).
     public static let system = Role(rawValue: "system")
-    
+
     /// A user message role.
     ///
     /// Use this role when providing user created input to the model.
     public static let user = Role(rawValue: "user")
-    
+
     /// An assitant role.
     ///
     /// Use this role when providing the model with one of its previous responses.
@@ -48,7 +48,7 @@ extension CactusLanguageModel.ChatMessage {
       self.rawValue = rawValue
     }
   }
-  
+
   /// Creates a system message.
   ///
   /// Use this initializer when providing instructions to the model
@@ -62,7 +62,7 @@ extension CactusLanguageModel.ChatMessage {
 
   /// Creates a user message.
   ///
-  /// Use this intiializer when providing user created input to the model.
+  /// Use this initializer when providing user created input to the model.
   ///
   /// - Parameter content: The message content.
   /// - Returns: A ``CactusLanguageModel/ChatMessage``.
@@ -72,7 +72,7 @@ extension CactusLanguageModel.ChatMessage {
 
   /// Creates an assistant message.
   ///
-  /// Use this intiializer when providing the model with one of its previous responses.
+  /// Use this initializer when providing the model with one of its previous responses.
   ///
   /// - Parameter content: The message content.
   /// - Returns: A ``CactusLanguageModel/ChatMessage``.

--- a/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Chat-Completion.1.json
+++ b/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Chat-Completion.1.json
@@ -1,9 +1,9 @@
 {
   "decode_tokens" : 200,
-  "prefill_tokens" : 34,
-  "response" : "<think>\nOkay, the user asked \"What is the meaning of life?\" which is a profound and philosophical question. As a philosopher and an AI assistant here to provide thoughtful answers.\n\nFirstly, I should acknowledge that this is indeed a complex topic. There are many views on life's meaning—some might seek purpose through work or happiness, others through love and family. It's subjective.\n\nBut since I'm an AI assistant, my role is to provide information based on available knowledge without making assumptions about personal experiences or beliefs beyond what is known scientifically and ethically. Therefore, I need to frame my response in a way that respects this limitation while offering some insight.\n\nI can start by stating that there are many perspectives on life's meaning—some seek purpose through work or happiness while others find joy in love and family. However, as an AI without personal experiences or beliefs, I cannot provide individual answers. Instead of trying to answer directly \"What is life's meaning?\" since it's subjective, I",
-  "time_to_first_token_ms" : 1245.89,
-  "tokens_per_second" : 32.02,
-  "total_time_ms" : 7460.15,
-  "total_tokens" : 234
+  "prefill_tokens" : 15,
+  "response" : "<think>\nOkay, so I need to figure out what life means. Hmm... Well first off, people have different views on this topic because it's really personal and varies from person to person.\n\nI remember reading somewhere that meaning comes from within us—our values and passions. But how do those translate into life? Maybe it's about personal growth through challenges. Like facing difficulties in life but learning from them.\n\nAlso, there are philosophical perspectives. For example, some believe meaning comes from the pursuit of knowledge and truth. Others think it's about contributing to society rather than just self-actualization.\n\nThere are also cultural factors here too. Different cultures have different ways of understanding what makes life meaningful—like religious beliefs or traditions influencing values.\n\nWait, but I'm not sure if I'm getting all this right. Maybe some people find meaning in family or friends. Others might value work or personal achievements.\n\nI should also consider how individuals perceive their own life goals. If someone has a dream they want",
+  "time_to_first_token_ms" : 5689.31,
+  "tokens_per_second" : 12.31,
+  "total_time_ms" : 21848.82,
+  "total_tokens" : 215
 }

--- a/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Tool-Calling.1.json
+++ b/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Tool-Calling.1.json
@@ -1,17 +1,9 @@
 {
-  "decode_tokens" : 31,
-  "function_call" : {
-    "function_call" : {
-      "arguments" : {
-        "location" : "Santa Cruz"
-      },
-      "name" : "get_weather"
-    }
-  },
+  "decode_tokens" : 200,
   "prefill_tokens" : 158,
-  "response" : "ingeses\n<\/think>\n\n```json",
-  "time_to_first_token_ms" : 1498.95,
-  "tokens_per_second" : 27.83,
-  "total_time_ms" : 2577.02,
-  "total_tokens" : 189
+  "response" : " gloria has a very interesting question! The weather in Santa Cruz depends on several factors such as time of day and location in relation with other cities.\nThe user might ask for information about the weather at Santa Cruz during different times such as morning, afternoon, evening and night.\nBut since you have access to get_weather function which can be used for any location (Santa Cruz), then I can answer directly using that function.\nSo I will call get_weather with location set as \"Santa Cruz\" as required by the function.\nThe response should be a JSON object containing the weather information from that function.\nIf there is no data available for Santa Cruz at any time of day (e.g., no rain), then it will return an empty object.\nThe function returns information such as temperature and precipitation for each hour.\nSo let me call get_weather with location set as \"Santa Cruz\".\nOkay, I need to use the get_weather function here. The parameters require 'location', so I'll input \"Santa Cruz",
+  "time_to_first_token_ms" : 6871.99,
+  "tokens_per_second" : 12.54,
+  "total_time_ms" : 22746.3,
+  "total_tokens" : 358
 }


### PR DESCRIPTION
Adds a new `DownloadTaskCreator` protocol which enables usage of `CactusModelsDirectory` to download models from custom destinations other then the cactus platform itself.