### PR TITLE
Don't require escaping closure for onToken callback

### DIFF
--- a/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Chat-Completion.1.json
+++ b/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Chat-Completion.1.json
@@ -3,10 +3,10 @@
   "function_calls" : [
 
   ],
-  "prefill_tokens" : 34,
-  "response" : "<think>\nAlright, so I need to explain what life means. Let me start by breaking down different perspectives from various sources.\n\nFirst off, from a philosophical standpoint: Life is often seen as an ongoing journey of experience, growth, challenges, etc., rather than a static object. Different cultures have unique views; maybe some emphasize harmony with nature while others focus more on individual achievement.\n\nThen there's the concept of meaning: people often seek answers to why life matters—what drives them? Is it purposeful living? Or is it about personal fulfillment?\n\nI should consider both spiritual and material aspects. Some believe life has a divine purpose (like religion) while others might value happiness as the ultimate goal regardless of external factors.\n\nAlso, life can be viewed as a series of moments—each contributing to the overall experience. It's dynamic; things change over time with new opportunities arising each day.\n\nI need to ensure that my answer covers these points clearly but concisely. Avoid jargon so it's",
-  "time_to_first_token_ms" : 654.48,
-  "tokens_per_second" : 18.77,
-  "total_time_ms" : 11254.33,
-  "total_tokens" : 234
+  "prefill_tokens" : 15,
+  "response" : "<think>\nOkay, the user asked for a definition of life. First, I need to recall different perspectives on this topic.\n\nThere's existentialism where people live their lives freely according to their own values and beliefs. Then there are cultural or philosophical views too, like those from different countries or traditions. The user might not know these specific perspectives yet so I should cover some key points from various sources.\n\nI should mention the concept of meaning as per existentialism but also include other dimensions. Including examples would help, like how people define life differently in different contexts. Make sure the answer is comprehensive yet clear.\n<\/think>\n\nThe concept of **meaning** can vary widely depending on individual perspectives, cultural values, personal beliefs, and philosophical frameworks. Here are some key viewpoints:\n\n### 1. **Existentialism**:  \n   - Emphasizes living authentically according to one’s own values and choices. The idea of *meaning* arises from personal freedom and self-determination.  \n   - For",
+  "time_to_first_token_ms" : 6410.04,
+  "tokens_per_second" : 19.38,
+  "total_time_ms" : 16679.23,
+  "total_tokens" : 215
 }

--- a/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Function-Calling.1.json
+++ b/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Basic-Function-Calling.1.json
@@ -10,8 +10,8 @@
   ],
   "prefill_tokens" : 160,
   "response" : "",
-  "time_to_first_token_ms" : 1461.3,
-  "tokens_per_second" : 12.25,
-  "total_time_ms" : 3175.83,
+  "time_to_first_token_ms" : 6742.71,
+  "tokens_per_second" : 14.14,
+  "total_time_ms" : 8227.37,
   "total_tokens" : 182
 }

--- a/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Multiple-Function-Calls.1.json
+++ b/Tests/CactusTests/LanguageModelTests/__Snapshots__/CactusLanguageModelTests/Multiple-Function-Calls.1.json
@@ -1,12 +1,35 @@
 {
-  "decode_tokens" : 90,
+  "decode_tokens" : 183,
   "function_calls" : [
-
+    {
+      "arguments" : {
+        "arg1" : "Berkeley"
+      },
+      "name" : "get_weather"
+    },
+    {
+      "arguments" : {
+        "arg1" : "Berkeley"
+      },
+      "name" : "get_population"
+    },
+    {
+      "arguments" : {
+        "arg1" : "Berkeley"
+      },
+      "name" : "get_weather"
+    },
+    {
+      "arguments" : {
+        "arg1 " : "Berkeley"
+      },
+      "name" : "get_population"
+    }
   ],
-  "prefill_tokens" : 252,
-  "response" : "I can retrieve both weather and population information for Berkeley using your tools.\n\n1. **Weather in Berkeley**:\n   - Use the `get_weather` function with location set to \"Berkeley\" and units specified (e.g., celsius or farenheit).\n\n2. **Population in Berkeley**:\n   - Use the `get_population` function with location set to \"Berkeley\".\n\nLet me know if you'd like specific units for weather!",
-  "time_to_first_token_ms" : 2006.02,
-  "tokens_per_second" : 16,
-  "total_time_ms" : 7569.18,
-  "total_tokens" : 342
+  "prefill_tokens" : 236,
+  "response" : "To find out both the weather and population in Berkeley:\n\n1. Use `get_weather` with location set to 'Berkeley' for weather.\n2. Use `get_population` with location set to 'Berkeley' for population data.\n\nHere's how you can make both calls:\n\nFor weather:\n```json\n{\"function_call\": {\"name\": \"get_weather\", \"arguments\": {\"arg1\": \"Berkeley\"}}}\n```\n\nFor population:\n```json\n{\"function_call\": {\"name\": \"get_population\", \"arguments\": {\"arg1\": \"Berkeley\"}}}\n```\n\nEach call will return the respective data about Berkeley's weather and population in detail.\n<\/think>\n{\"function_call\": {\"name\": \"get_weather\", \"arguments\": {\"arg1\": \"Berkeley\"}}}",
+  "time_to_first_token_ms" : 7019.21,
+  "tokens_per_second" : 17.52,
+  "total_time_ms" : 17405.65,
+  "total_tokens" : 419
 }


### PR DESCRIPTION
The closure only needed to be escaping because of an internal class that had its reference count managed manually, and was guaranteed to be deallocated after generating the completion. So `withoutActuallyEscaping` can be used as a work around.