### PR TITLE
`@CactusEntry` Macro

### DIFF
--- a/Sources/Cactus/Macros.swift
+++ b/Sources/Cactus/Macros.swift
@@ -1,0 +1,3 @@
+@attached(accessor)
+@attached(peer, names: prefixed(__Key_))
+public macro CactusEntry() = #externalMacro(module: "CactusMacros", type: "CactusEntryMacro")

--- a/Sources/CactusMacros/CactusEntryMacro.swift
+++ b/Sources/CactusMacros/CactusEntryMacro.swift
@@ -1,0 +1,102 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum CactusEntryMacro: PeerMacro, AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let extensionType = context.lexicalContext.first?
+      .as(ExtensionDeclSyntax.self)?
+      .extendedType
+      .as(IdentifierTypeSyntax.self)
+
+    guard extensionType?.name.text == "CactusEnvironmentValues" else {
+      throw MacroExpansionErrorMessage(
+        "@CactusEntry can only be used inside an extension of CactusEnvironmentValues."
+      )
+    }
+
+    guard let variableDecl = declaration.as(VariableDeclSyntax.self),
+      let binding = variableDecl.bindings.first,
+      binding.accessorBlock == nil
+    else {
+      throw MacroExpansionErrorMessage("@CactusEntry can only be applied to a stored property.")
+    }
+    guard let identifierPattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
+      throw MacroExpansionErrorMessage("@CactusEntry must be applied to a simple identifier.")
+    }
+
+    let name = identifierPattern.identifier.text
+    let keyTypeName = "__Key_\(name)"
+    let isExplicitlyOptionalType = binding.typeAnnotation?.type.isOptional ?? false
+    guard binding.initializer != nil || isExplicitlyOptionalType else {
+      throw MacroExpansionErrorMessage(
+        "@CactusEntry requires a default value for a non-optional type."
+      )
+    }
+
+    let peerStruct: EnumDeclSyntax
+
+    if let type = binding.typeAnnotation?.type.valueTypeName {
+      peerStruct = try EnumDeclSyntax(
+        """
+        private enum \(raw: keyTypeName): CactusCore.CactusEnvironmentValues.Key
+        """
+      ) {
+        DeclSyntax("static let defaultValue: \(raw: type)= \(binding.initializer?.value ?? "nil")")
+      }
+    } else {
+      peerStruct = try EnumDeclSyntax(
+        """
+        private enum \(raw: keyTypeName): CactusCore.CactusEnvironmentValues.Key
+        """
+      ) {
+        DeclSyntax("static let defaultValue = \(binding.initializer?.value ?? "nil")")
+      }
+    }
+    return [DeclSyntax(peerStruct)]
+  }
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    guard let variableDecl = declaration.as(VariableDeclSyntax.self),
+      let binding = variableDecl.bindings.first,
+      let identifierPattern = binding.pattern.as(IdentifierPatternSyntax.self)
+    else {
+      throw MacroExpansionErrorMessage("@CactusEntry can only be applied to a single variable.")
+    }
+
+    let name = identifierPattern.identifier.text
+    let keyTypeName = "__Key_\(name)"
+
+    let getAccessor: AccessorDeclSyntax =
+      """
+      get { self[\(raw: keyTypeName).self] }
+      """
+
+    if variableDecl.bindingSpecifier.tokenKind == .keyword(.var) {
+      let setAccessor: AccessorDeclSyntax =
+        """
+        set { self[\(raw: keyTypeName).self] = newValue }
+        """
+      return [getAccessor, setAccessor]
+    } else {
+      throw MacroExpansionErrorMessage("@CactusEntry can only be applied to a 'var' declaration.")
+    }
+  }
+}
+
+extension TypeSyntax {
+  fileprivate var valueTypeName: String {
+    if self.description.contains("!") {
+      self.description.dropLast() + "?"
+    } else {
+      self.description
+    }
+  }
+}

--- a/Sources/CactusMacros/Internal/TypeSyntax+Extensions.swift
+++ b/Sources/CactusMacros/Internal/TypeSyntax+Extensions.swift
@@ -1,0 +1,9 @@
+import SwiftSyntax
+
+extension TypeSyntax {
+  var isOptional: Bool {
+    self.description.contains("?")
+      || self.description.starts(with: "Optional<")
+      || self.description.contains("!")
+  }
+}

--- a/Sources/CactusMacros/Plugin.swift
+++ b/Sources/CactusMacros/Plugin.swift
@@ -3,5 +3,5 @@ import SwiftSyntaxMacros
 
 @main
 struct OperationMacrosPlugin: CompilerPlugin {
-  let providingMacros: [any Macro.Type] = []
+  let providingMacros: [any Macro.Type] = [CactusEntryMacro.self]
 }

--- a/Tests/CactusMacrosTests/BaseTestSuite.swift
+++ b/Tests/CactusMacrosTests/BaseTestSuite.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite(
   .serialized,
   .macros(
-    [],
+    ["CactusEntry": CactusEntryMacro.self],
     record: .failed
   )
 ) struct BaseTestSuite {}

--- a/Tests/CactusMacrosTests/CactusEntryMacroTests.swift
+++ b/Tests/CactusMacrosTests/CactusEntryMacroTests.swift
@@ -1,0 +1,351 @@
+import MacroTesting
+import Testing
+
+extension BaseTestSuite {
+  @Suite
+  struct `CactusEntryMacro tests` {
+    @Test
+    func `Basic Context Property`() {
+      assertMacro {
+        """
+        extension CactusEnvironmentValues {
+          @CactusEntry var property = "blob"
+        }
+        """
+      } expansion: {
+        """
+        extension CactusEnvironmentValues {
+          var property {
+            get {
+              self[__Key_property.self]
+            }
+            set {
+              self[__Key_property.self] = newValue
+            }
+          }
+
+          private enum __Key_property: CactusCore.CactusEnvironmentValues.Key {
+            static let defaultValue = "blob"
+          }
+        }
+        """
+      }
+    }
+
+    @Test
+    func `Optional Context Property`() {
+      assertMacro {
+        """
+        extension CactusEnvironmentValues {
+          @CactusEntry var property: String?
+        }
+        """
+      } expansion: {
+        """
+        extension CactusEnvironmentValues {
+          var property: String? {
+            get {
+              self[__Key_property.self]
+            }
+            set {
+              self[__Key_property.self] = newValue
+            }
+          }
+
+          private enum __Key_property: CactusCore.CactusEnvironmentValues.Key {
+            static let defaultValue: String? = nil
+          }
+        }
+        """
+      }
+      assertMacro {
+        """
+        extension CactusEnvironmentValues {
+          @CactusEntry var property: Optional<String>
+        }
+        """
+      } expansion: {
+        """
+        extension CactusEnvironmentValues {
+          var property: Optional<String> {
+            get {
+              self[__Key_property.self]
+            }
+            set {
+              self[__Key_property.self] = newValue
+            }
+          }
+
+          private enum __Key_property: CactusCore.CactusEnvironmentValues.Key {
+            static let defaultValue: Optional<String> = nil
+          }
+        }
+        """
+      }
+      assertMacro {
+        """
+        extension CactusEnvironmentValues {
+          @CactusEntry var property: String!
+        }
+        """
+      } expansion: {
+        """
+        extension CactusEnvironmentValues {
+          var property: String! {
+            get {
+              self[__Key_property.self]
+            }
+            set {
+              self[__Key_property.self] = newValue
+            }
+          }
+
+          private enum __Key_property: CactusCore.CactusEnvironmentValues.Key {
+            static let defaultValue: String? = nil
+          }
+        }
+        """
+      }
+    }
+
+    @Test
+    func `Multiline Context Property`() {
+      assertMacro {
+        """
+        extension CactusEnvironmentValues {
+          @CactusEntry var property = {
+            var b = "blob"
+            b = someTransform(b)
+            return b.trimmingCharacters(in: .whitespacesAndNewlines)
+          }()
+        }
+        """
+      } expansion: {
+        """
+        extension CactusEnvironmentValues {
+          var property {
+            get {
+              self[__Key_property.self]
+            }
+            set {
+              self[__Key_property.self] = newValue
+            }
+          }
+
+          private enum __Key_property: CactusCore.CactusEnvironmentValues.Key {
+            static let defaultValue = {
+                var b = "blob"
+                b = someTransform(b)
+                return b.trimmingCharacters(in: .whitespacesAndNewlines)
+              }()
+          }
+        }
+        """
+      }
+    }
+
+    @Test
+    func `Access Control Context Property`() {
+      assertMacro {
+        """
+        extension CactusEnvironmentValues {
+          @CactusEntry public var property = "blob"
+        }
+        """
+      } expansion: {
+        """
+        extension CactusEnvironmentValues {
+          public var property {
+            get {
+              self[__Key_property.self]
+            }
+            set {
+              self[__Key_property.self] = newValue
+            }
+          }
+
+          private enum __Key_property: CactusCore.CactusEnvironmentValues.Key {
+            static let defaultValue = "blob"
+          }
+        }
+        """
+      }
+    }
+
+    @Test
+    func `Read-Only Context Property`() {
+      assertMacro {
+        """
+        extension CactusEnvironmentValues {
+          @CactusEntry let property = "blob"
+        }
+        """
+      } diagnostics: {
+        """
+        extension CactusEnvironmentValues {
+          @CactusEntry let property = "blob"
+          ┬───────────
+          ╰─ 🛑 @CactusEntry can only be applied to a 'var' declaration.
+        }
+        """
+      }
+    }
+
+    @Test
+    func `Private Context Property`() {
+      assertMacro {
+        """
+        extension CactusEnvironmentValues {
+          @CactusEntry private var property = "blob"
+        }
+        """
+      } expansion: {
+        """
+        extension CactusEnvironmentValues {
+          private var property {
+            get {
+              self[__Key_property.self]
+            }
+            set {
+              self[__Key_property.self] = newValue
+            }
+          }
+
+          private enum __Key_property: CactusCore.CactusEnvironmentValues.Key {
+            static let defaultValue = "blob"
+          }
+        }
+        """
+      }
+    }
+
+    @Test
+    func `Explicitly Typed Context Property`() {
+      assertMacro {
+        """
+        struct Foo {}
+
+        extension CactusEnvironmentValues {
+          @CactusEntry var property: Foo = .init()
+        }
+        """
+      } expansion: {
+        """
+        struct Foo {}
+
+        extension CactusEnvironmentValues {
+          var property: Foo {
+            get {
+              self[__Key_property.self]
+            }
+            set {
+              self[__Key_property.self] = newValue
+            }
+          }
+
+          private enum __Key_property: CactusCore.CactusEnvironmentValues.Key {
+            static let defaultValue: Foo = .init()
+          }
+        }
+        """
+      }
+    }
+
+    @Test
+    func `Global Actor Context Property`() {
+      assertMacro {
+        """
+        extension CactusEnvironmentValues {
+          @MainActor @CactusEntry var property = "blob"
+        }
+        """
+      } expansion: {
+        """
+        extension CactusEnvironmentValues {
+          @MainActor var property {
+            get {
+              self[__Key_property.self]
+            }
+            set {
+              self[__Key_property.self] = newValue
+            }
+          }
+
+          private enum __Key_property: CactusCore.CactusEnvironmentValues.Key {
+            static let defaultValue = "blob"
+          }
+        }
+        """
+      }
+    }
+
+    @Test
+    func `Used Outside CactusEnvironmentValues Extension`() {
+      assertMacro {
+        """
+        struct Foo {
+          @CactusEntry var property = "blob"
+        }
+        """
+      } diagnostics: {
+        """
+        struct Foo {
+          @CactusEntry var property = "blob"
+          ┬───────────
+          ╰─ 🛑 @CactusEntry can only be used inside an extension of CactusEnvironmentValues.
+        }
+        """
+      }
+    }
+
+    @Test
+    func `Computed Context Property`() {
+      assertMacro {
+        """
+        struct Foo {}
+
+        extension CactusEnvironmentValues {
+          @CactusEntry var property: Foo {
+            Foo()
+          }
+        }
+        """
+      } diagnostics: {
+        """
+        struct Foo {}
+
+        extension CactusEnvironmentValues {
+          @CactusEntry var property: Foo {
+          ┬───────────
+          ╰─ 🛑 @CactusEntry can only be applied to a stored property.
+            Foo()
+          }
+        }
+        """
+      }
+    }
+
+    @Test
+    func `No Default Value Context Property`() {
+      assertMacro {
+        """
+        struct Foo {}
+
+        extension CactusEnvironmentValues {
+          @CactusEntry var property: Foo
+        }
+        """
+      } diagnostics: {
+        """
+        struct Foo {}
+
+        extension CactusEnvironmentValues {
+          @CactusEntry var property: Foo
+          ┬───────────
+          ╰─ 🛑 @CactusEntry requires a default value for a non-optional type.
+        }
+        """
+      }
+    }
+  }
+}

--- a/Tests/CactusTests/AgentsTests/EnvironmentTests/CactusEnvironmentValuesTests.swift
+++ b/Tests/CactusTests/AgentsTests/EnvironmentTests/CactusEnvironmentValuesTests.swift
@@ -23,12 +23,12 @@ struct `CactusEnvironmentValues tests` {
     expectNoDifference(values.description, "[]")
 
     values.test = _defaultValue + 200
-    expectNoDifference(values.description, "[CactusEnvironmentValues.TestKey = \(values.test)]")
+    expectNoDifference(values.description, "[CactusEnvironmentValues.__Key_test = \(values.test)]")
 
     values.test2 = "Vlov"
     let expected = Set([
-      "[CactusEnvironmentValues.TestKey = \(values.test), CactusEnvironmentValues.Test2Key = Vlov]",
-      "[CactusEnvironmentValues.Test2Key = Vlov, CactusEnvironmentValues.TestKey = \(values.test)]"
+      "[CactusEnvironmentValues.__Key_test = \(values.test), CactusEnvironmentValues.Test2Key = Vlov]",
+      "[CactusEnvironmentValues.Test2Key = Vlov, CactusEnvironmentValues.__Key_test = \(values.test)]"
     ])
     expectNoDifference(expected.contains(values.description), true)
   }
@@ -37,14 +37,7 @@ struct `CactusEnvironmentValues tests` {
 private let _defaultValue = 100
 
 extension CactusEnvironmentValues {
-  fileprivate var test: Int {
-    get { self[TestKey.self] }
-    set { self[TestKey.self] = newValue }
-  }
-
-  private enum TestKey: Key {
-    static let defaultValue = _defaultValue
-  }
+  @CactusEntry fileprivate var test = _defaultValue
 
   fileprivate var test2: String {
     get { self[Test2Key.self] }


### PR DESCRIPTION
Adds a macro that behaves like SwiftUI's `@Entry` for `ContextEnvironmentValues`.