### PR TITLE
Update Response Protocol

### DIFF
--- a/Sources/CactusCore/Agents/ConvertibleFromCactusResponse.swift
+++ b/Sources/CactusCore/Agents/ConvertibleFromCactusResponse.swift
@@ -1,6 +1,6 @@
 // MARK: - ConvertibleFromCactusResponse
 
-public protocol ConvertibleFromCactusResponse: CactusPromptRepresentable {
+public protocol ConvertibleFromCactusResponse {
   associatedtype Partial: ConvertibleFromCactusResponse = Self
   associatedtype ConversionFailure: Error
 

--- a/Sources/CactusCore/Agents/Whisper/WhisperTranscriptionResponse.swift
+++ b/Sources/CactusCore/Agents/Whisper/WhisperTranscriptionResponse.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct WhipserTranscriptionResponse: Hashable, Sendable, ConvertibleFromCactusResponse {
+public enum WhipserTranscriptionResponse: Hashable, Sendable, ConvertibleFromCactusResponse {
   public struct Timestamp: Hashable, Sendable {
     public let seconds: TimeInterval
     public let transcript: String
@@ -11,27 +11,17 @@ public struct WhipserTranscriptionResponse: Hashable, Sendable, ConvertibleFromC
     }
   }
 
-  public enum Kind: Hashable, Sendable {
-    case fullTranscript(String)
-    case timestamps([Timestamp])
-  }
-
-  public let cactusResponse: String
-  public let kind: Kind
-
-  public var promptContent: CactusPromptContent {
-    CactusPromptContent(text: self.cactusResponse)
-  }
+  case fullTranscript(String)
+  case timestamps([Timestamp])
 
   public init(cactusResponse: String) {
     let fullTranscript = cactusResponse.replacingOccurrences(of: "<|startoftranscript|>", with: "")
     let matchGroups = responseRegex.matchGroups(from: fullTranscript)
-    self.cactusResponse = cactusResponse
 
     if matchGroups.isEmpty {
-      self.kind = .fullTranscript(fullTranscript)
+      self = .fullTranscript(fullTranscript)
     } else {
-      self.kind = .timestamps(
+      self = .timestamps(
         stride(from: 0, to: matchGroups.count, by: 2)
           .compactMap { i in
             guard let seconds = TimeInterval(matchGroups[i]) else { return nil }

--- a/Tests/CactusTests/AgentsTests/WhisperTests/WhisperTranscriptionResponseTests.swift
+++ b/Tests/CactusTests/AgentsTests/WhisperTests/WhisperTranscriptionResponseTests.swift
@@ -7,7 +7,7 @@ struct `WhisperTranscriptionResponse tests` {
   @Test
   func `Empty String Response`() {
     let response = WhipserTranscriptionResponse(cactusResponse: "")
-    expectNoDifference(response.kind, .fullTranscript(""))
+    expectNoDifference(response, .fullTranscript(""))
   }
 
   @Test
@@ -26,7 +26,7 @@ struct `WhisperTranscriptionResponse tests` {
       Even gods are merely beings restricted to the limited power determined by prophets. That \
       power, although great, is not unlimited. That voice, Albrecht! How dare you!
       """
-    expectNoDifference(response.kind, .fullTranscript(transcript))
+    expectNoDifference(response, .fullTranscript(transcript))
   }
 
   @Test
@@ -42,7 +42,7 @@ struct `WhisperTranscriptionResponse tests` {
         """
     )
     expectNoDifference(
-      response.kind,
+      response,
       .timestamps([
         WhipserTranscriptionResponse.Timestamp(
           seconds: 0,


### PR DESCRIPTION
`ConvertibleFromCactusResponse` originally inherited from `CactusPromptRepresentable` such that the response type could be appended directly to the transcript. However, some response types (eg. `WhisperTranscriptionResponse`) don't necessarily really belong in the transcript, so we should relax this requirement.