### PR TITLE
New Convenience JSONSchema APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,14 @@ let completion = try model.chatCompletion(
       name: "get_weather",
       description: "Get the weather in a given location",
       parameters: .object(
-        valueSchema: .object(
-          properties: [
-            "location": .object(
-              description: "City name, eg. 'San Francisco'",
-              valueSchema: .string(minLength: 1),
-              examples: ["San Francisco"]
-            )
-          ],
-          required: ["location"]
-        )
+        properties: [
+          "location": .string(
+            description: "City name, eg. 'San Francisco'",
+            minLength: 1,
+            examples: ["San Francisco"]
+          )
+        ],
+        required: ["location"]
       )
     )
   ]
@@ -145,11 +143,9 @@ print(completion.functionCalls)
 >   name: "search",
 >   description: "Find something",
 >   parameters: .object(
->     valueSchema: .object(
->       properties: [
->         "query": .object(valueSchema: .string(minLength: 1))
->       ]
->     )
+>     properties: [
+>       "query": .string(minLength: 1)
+>     ]
 >   )
 > )
 > let completion = try model.chatCompletion(

--- a/Sources/Cactus/Documentation.docc/Cactus.md
+++ b/Sources/Cactus/Documentation.docc/Cactus.md
@@ -110,16 +110,14 @@ let completion = try model.chatCompletion(
       name: "get_weather",
       description: "Get the weather in a given location",
       parameters: .object(
-        valueSchema: .object(
-          properties: [
-            "location": .object(
-              description: "City name, eg. 'San Francisco'",
-              valueSchema: .string(minLength: 1),
-              examples: ["San Francisco"]
-            )
-          ],
-          required: ["location"]
-        )
+        properties: [
+          "location": .string(
+            description: "City name, eg. 'San Francisco'",
+            minLength: 1,
+            examples: ["San Francisco"]
+          )
+        ],
+        required: ["location"]
       )
     )
   ]
@@ -140,11 +138,9 @@ print(completion.functionCalls)
 >   name: "search",
 >   description: "Find something",
 >   parameters: .object(
->     valueSchema: .object(
->       properties: [
->         "query": .object(valueSchema: .string(minLength: 1))
->       ]
->     )
+>     properties: [
+>       "query": .string(minLength: 1)
+>     ]
 >   )
 > )
 > let completion = try model.chatCompletion(

--- a/Sources/Cactus/JSONSchema/JSONSchema+Validation.swift
+++ b/Sources/Cactus/JSONSchema/JSONSchema+Validation.swift
@@ -9,11 +9,9 @@ extension JSONSchema {
   ///   name: "search",
   ///   description: "Find something",
   ///   parameters: .object(
-  ///     valueSchema: .object(
-  ///       properties: [
-  ///         "query": .object(valueSchema: .string(minLength: 1))
-  ///       ]
-  ///     )
+  ///     properties: [
+  ///       "query": .string(minLength: 1)
+  ///     ]
   ///   )
   /// )
   /// let completion = try model.chatCompletion(

--- a/Sources/Cactus/JSONSchema/JSONSchema.swift
+++ b/Sources/Cactus/JSONSchema/JSONSchema.swift
@@ -229,6 +229,611 @@ extension JSONSchema {
       )
     )
   }
+
+  private static func typed(
+    title: String? = nil,
+    description: String? = nil,
+    valueSchema: ValueSchema,
+    `default`: Value? = nil,
+    readOnly: Bool? = nil,
+    writeOnly: Bool? = nil,
+    examples: [Value]? = nil,
+    `enum`: [Value]? = nil,
+    const: Value? = nil,
+    allOf: [JSONSchema]? = nil,
+    anyOf: [JSONSchema]? = nil,
+    oneOf: [JSONSchema]? = nil,
+    not: JSONSchema? = nil,
+    `if`: JSONSchema? = nil,
+    then: JSONSchema? = nil,
+    `else`: JSONSchema? = nil,
+    format: String? = nil
+  ) -> Self {
+    .object(
+      title: title,
+      description: description,
+      valueSchema: valueSchema,
+      default: `default`,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      examples: examples,
+      enum: `enum`,
+      const: const,
+      allOf: allOf,
+      anyOf: anyOf,
+      oneOf: oneOf,
+      not: not,
+      if: `if`,
+      then: then,
+      else: `else`,
+      format: format
+    )
+  }
+
+  /// Creates a string-specific object schema.
+  ///
+  /// - Parameters:
+  ///   - title: The title of the schema.
+  ///   - description: The description of the schema.
+  ///   - minLength: The minimum length of the string.
+  ///   - maxLength: The maximum length of the string.
+  ///   - pattern: A regular expression that the string must match.
+  ///   - default: The default value of the schema.
+  ///   - readOnly: Indicates whether the value is managed exclusively by the owning authority.
+  ///   - writeOnly: Indicates whether the value is present when retrieved from the owning authority.
+  ///   - examples: A list of example values.
+  ///   - enum: A list of allowed values.
+  ///   - const: The only allowed value.
+  ///   - allOf: A list of schemas in which the value must match all of them.
+  ///   - anyOf: A list of schemas in which the value must match at least one of them.
+  ///   - oneOf: A list of schemas in which the value must match exactly one of them.
+  ///   - not: A schema that the value must not match.
+  ///   - if: A schema to use for control flow.
+  ///   - then: A schema to match against if a value successfully matches against ``Object/if``.
+  ///   - else: A schema to match against if a value fails to match against ``Object/if``.
+  ///   - format: A string containing information for validating values not confined with the JSON Schema specification.
+  public static func string(
+    title: String? = nil,
+    description: String? = nil,
+    minLength: Int? = nil,
+    maxLength: Int? = nil,
+    pattern: String? = nil,
+    `default`: Value? = nil,
+    readOnly: Bool? = nil,
+    writeOnly: Bool? = nil,
+    examples: [Value]? = nil,
+    `enum`: [Value]? = nil,
+    const: Value? = nil,
+    allOf: [JSONSchema]? = nil,
+    anyOf: [JSONSchema]? = nil,
+    oneOf: [JSONSchema]? = nil,
+    not: JSONSchema? = nil,
+    `if`: JSONSchema? = nil,
+    then: JSONSchema? = nil,
+    `else`: JSONSchema? = nil,
+    format: String? = nil
+  ) -> Self {
+    .typed(
+      title: title,
+      description: description,
+      valueSchema: .string(minLength: minLength, maxLength: maxLength, pattern: pattern),
+      default: `default`,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      examples: examples,
+      enum: `enum`,
+      const: const,
+      allOf: allOf,
+      anyOf: anyOf,
+      oneOf: oneOf,
+      not: not,
+      if: `if`,
+      then: then,
+      else: `else`,
+      format: format
+    )
+  }
+
+  /// Creates a number-specific object schema.
+  ///
+  /// - Parameters:
+  ///   - title: The title of the schema.
+  ///   - description: The description of the schema.
+  ///   - multipleOf: The value that the number must be a multiple of.
+  ///   - minimum: The minimum value (inclusive) of the number.
+  ///   - exclusiveMinimum: The minimum value (exclusive) of the number.
+  ///   - maximum: The maximum value (inclusive) of the number.
+  ///   - exclusiveMaximum: The maximum value (exclusive) of the number.
+  ///   - default: The default value of the schema.
+  ///   - readOnly: Indicates whether the value is managed exclusively by the owning authority.
+  ///   - writeOnly: Indicates whether the value is present when retrieved from the owning authority.
+  ///   - examples: A list of example values.
+  ///   - enum: A list of allowed values.
+  ///   - const: The only allowed value.
+  ///   - allOf: A list of schemas in which the value must match all of them.
+  ///   - anyOf: A list of schemas in which the value must match at least one of them.
+  ///   - oneOf: A list of schemas in which the value must match exactly one of them.
+  ///   - not: A schema that the value must not match.
+  ///   - if: A schema to use for control flow.
+  ///   - then: A schema to match against if a value successfully matches against ``Object/if``.
+  ///   - else: A schema to match against if a value fails to match against ``Object/if``.
+  ///   - format: A string containing information for validating values not confined with the JSON Schema specification.
+  public static func number(
+    title: String? = nil,
+    description: String? = nil,
+    multipleOf: Double? = nil,
+    minimum: Double? = nil,
+    exclusiveMinimum: Double? = nil,
+    maximum: Double? = nil,
+    exclusiveMaximum: Double? = nil,
+    `default`: Value? = nil,
+    readOnly: Bool? = nil,
+    writeOnly: Bool? = nil,
+    examples: [Value]? = nil,
+    `enum`: [Value]? = nil,
+    const: Value? = nil,
+    allOf: [JSONSchema]? = nil,
+    anyOf: [JSONSchema]? = nil,
+    oneOf: [JSONSchema]? = nil,
+    not: JSONSchema? = nil,
+    `if`: JSONSchema? = nil,
+    then: JSONSchema? = nil,
+    `else`: JSONSchema? = nil,
+    format: String? = nil
+  ) -> Self {
+    .typed(
+      title: title,
+      description: description,
+      valueSchema: .number(
+        multipleOf: multipleOf,
+        minimum: minimum,
+        exclusiveMinimum: exclusiveMinimum,
+        maximum: maximum,
+        exclusiveMaximum: exclusiveMaximum
+      ),
+      default: `default`,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      examples: examples,
+      enum: `enum`,
+      const: const,
+      allOf: allOf,
+      anyOf: anyOf,
+      oneOf: oneOf,
+      not: not,
+      if: `if`,
+      then: then,
+      else: `else`,
+      format: format
+    )
+  }
+
+  /// Creates an integer-specific object schema.
+  ///
+  /// - Parameters:
+  ///   - title: The title of the schema.
+  ///   - description: The description of the schema.
+  ///   - multipleOf: The value that the integer must be a multiple of.
+  ///   - minimum: The minimum value (inclusive) of the integer.
+  ///   - exclusiveMinimum: The minimum value (exclusive) of the integer.
+  ///   - maximum: The maximum value (inclusive) of the integer.
+  ///   - exclusiveMaximum: The maximum value (exclusive) of the integer.
+  ///   - default: The default value of the schema.
+  ///   - readOnly: Indicates whether the value is managed exclusively by the owning authority.
+  ///   - writeOnly: Indicates whether the value is present when retrieved from the owning authority.
+  ///   - examples: A list of example values.
+  ///   - enum: A list of allowed values.
+  ///   - const: The only allowed value.
+  ///   - allOf: A list of schemas in which the value must match all of them.
+  ///   - anyOf: A list of schemas in which the value must match at least one of them.
+  ///   - oneOf: A list of schemas in which the value must match exactly one of them.
+  ///   - not: A schema that the value must not match.
+  ///   - if: A schema to use for control flow.
+  ///   - then: A schema to match against if a value successfully matches against ``Object/if``.
+  ///   - else: A schema to match against if a value fails to match against ``Object/if``.
+  ///   - format: A string containing information for validating values not confined with the JSON Schema specification.
+  public static func integer(
+    title: String? = nil,
+    description: String? = nil,
+    multipleOf: Int? = nil,
+    minimum: Int? = nil,
+    exclusiveMinimum: Int? = nil,
+    maximum: Int? = nil,
+    exclusiveMaximum: Int? = nil,
+    `default`: Value? = nil,
+    readOnly: Bool? = nil,
+    writeOnly: Bool? = nil,
+    examples: [Value]? = nil,
+    `enum`: [Value]? = nil,
+    const: Value? = nil,
+    allOf: [JSONSchema]? = nil,
+    anyOf: [JSONSchema]? = nil,
+    oneOf: [JSONSchema]? = nil,
+    not: JSONSchema? = nil,
+    `if`: JSONSchema? = nil,
+    then: JSONSchema? = nil,
+    `else`: JSONSchema? = nil,
+    format: String? = nil
+  ) -> Self {
+    .typed(
+      title: title,
+      description: description,
+      valueSchema: .integer(
+        multipleOf: multipleOf,
+        minimum: minimum,
+        exclusiveMinimum: exclusiveMinimum,
+        maximum: maximum,
+        exclusiveMaximum: exclusiveMaximum
+      ),
+      default: `default`,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      examples: examples,
+      enum: `enum`,
+      const: const,
+      allOf: allOf,
+      anyOf: anyOf,
+      oneOf: oneOf,
+      not: not,
+      if: `if`,
+      then: then,
+      else: `else`,
+      format: format
+    )
+  }
+
+  /// Creates an array-specific object schema.
+  ///
+  /// - Parameters:
+  ///   - title: The title of the schema.
+  ///   - description: The description of the schema.
+  ///   - items: The schema for the items in the array.
+  ///   - additionalItems: A schema describing elements not covered by `items`.
+  ///   - minItems: The minimum number of items allowed in the array.
+  ///   - maxItems: The maximum number of items allowed in the array.
+  ///   - uniqueItems: A boolean that indicates whether all items in the array must be unique.
+  ///   - contains: A schema that must be contained within the array.
+  ///   - default: The default value of the schema.
+  ///   - readOnly: Indicates whether the value is managed exclusively by the owning authority.
+  ///   - writeOnly: Indicates whether the value is present when retrieved from the owning authority.
+  ///   - examples: A list of example values.
+  ///   - enum: A list of allowed values.
+  ///   - const: The only allowed value.
+  ///   - allOf: A list of schemas in which the value must match all of them.
+  ///   - anyOf: A list of schemas in which the value must match at least one of them.
+  ///   - oneOf: A list of schemas in which the value must match exactly one of them.
+  ///   - not: A schema that the value must not match.
+  ///   - if: A schema to use for control flow.
+  ///   - then: A schema to match against if a value successfully matches against ``Object/if``.
+  ///   - else: A schema to match against if a value fails to match against ``Object/if``.
+  ///   - format: A string containing information for validating values not confined with the JSON Schema specification.
+  public static func array(
+    title: String? = nil,
+    description: String? = nil,
+    items: ValueSchema.Array.Items? = nil,
+    additionalItems: JSONSchema? = nil,
+    minItems: Int? = nil,
+    maxItems: Int? = nil,
+    uniqueItems: Bool? = nil,
+    contains: JSONSchema? = nil,
+    `default`: Value? = nil,
+    readOnly: Bool? = nil,
+    writeOnly: Bool? = nil,
+    examples: [Value]? = nil,
+    `enum`: [Value]? = nil,
+    const: Value? = nil,
+    allOf: [JSONSchema]? = nil,
+    anyOf: [JSONSchema]? = nil,
+    oneOf: [JSONSchema]? = nil,
+    not: JSONSchema? = nil,
+    `if`: JSONSchema? = nil,
+    then: JSONSchema? = nil,
+    `else`: JSONSchema? = nil,
+    format: String? = nil
+  ) -> Self {
+    .typed(
+      title: title,
+      description: description,
+      valueSchema: .array(
+        items: items,
+        additionalItems: additionalItems,
+        minItems: minItems,
+        maxItems: maxItems,
+        uniqueItems: uniqueItems,
+        contains: contains
+      ),
+      default: `default`,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      examples: examples,
+      enum: `enum`,
+      const: const,
+      allOf: allOf,
+      anyOf: anyOf,
+      oneOf: oneOf,
+      not: not,
+      if: `if`,
+      then: then,
+      else: `else`,
+      format: format
+    )
+  }
+
+  /// Creates an object-specific object schema.
+  ///
+  /// - Parameters:
+  ///   - title: The title of the schema.
+  ///   - description: The description of the schema.
+  ///   - properties: A dictionary of property names and their corresponding schemas.
+  ///   - required: An array of required property names.
+  ///   - minProperties: The minimum number of properties the object must have.
+  ///   - maxProperties: The maximum number of properties the object can have.
+  ///   - additionalProperties: A schema that defines constraints for additional properties not defined on the object.
+  ///   - patternProperties: A dictionary of regex patterns and corresponding schemas for matching property names.
+  ///   - propertyNames: A schema that defines constraints for property names.
+  ///   - default: The default value of the schema.
+  ///   - readOnly: Indicates whether the value is managed exclusively by the owning authority.
+  ///   - writeOnly: Indicates whether the value is present when retrieved from the owning authority.
+  ///   - examples: A list of example values.
+  ///   - enum: A list of allowed values.
+  ///   - const: The only allowed value.
+  ///   - allOf: A list of schemas in which the value must match all of them.
+  ///   - anyOf: A list of schemas in which the value must match at least one of them.
+  ///   - oneOf: A list of schemas in which the value must match exactly one of them.
+  ///   - not: A schema that the value must not match.
+  ///   - if: A schema to use for control flow.
+  ///   - then: A schema to match against if a value successfully matches against ``Object/if``.
+  ///   - else: A schema to match against if a value fails to match against ``Object/if``.
+  ///   - format: A string containing information for validating values not confined with the JSON Schema specification.
+  public static func object(
+    title: String? = nil,
+    description: String? = nil,
+    properties: [String: JSONSchema]? = nil,
+    required: [String]? = nil,
+    minProperties: Int? = nil,
+    maxProperties: Int? = nil,
+    additionalProperties: JSONSchema? = nil,
+    patternProperties: [String: JSONSchema]? = nil,
+    propertyNames: JSONSchema? = nil,
+    `default`: Value? = nil,
+    readOnly: Bool? = nil,
+    writeOnly: Bool? = nil,
+    examples: [Value]? = nil,
+    `enum`: [Value]? = nil,
+    const: Value? = nil,
+    allOf: [JSONSchema]? = nil,
+    anyOf: [JSONSchema]? = nil,
+    oneOf: [JSONSchema]? = nil,
+    not: JSONSchema? = nil,
+    `if`: JSONSchema? = nil,
+    then: JSONSchema? = nil,
+    `else`: JSONSchema? = nil,
+    format: String? = nil
+  ) -> Self {
+    .typed(
+      title: title,
+      description: description,
+      valueSchema: .object(
+        properties: properties,
+        required: required,
+        minProperties: minProperties,
+        maxProperties: maxProperties,
+        additionalProperties: additionalProperties,
+        patternProperties: patternProperties,
+        propertyNames: propertyNames
+      ),
+      default: `default`,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      examples: examples,
+      enum: `enum`,
+      const: const,
+      allOf: allOf,
+      anyOf: anyOf,
+      oneOf: oneOf,
+      not: not,
+      if: `if`,
+      then: then,
+      else: `else`,
+      format: format
+    )
+  }
+
+  /// Creates a null-specific object schema.
+  ///
+  /// - Parameters:
+  ///   - title: The title of the schema.
+  ///   - description: The description of the schema.
+  ///   - default: The default value of the schema.
+  ///   - readOnly: Indicates whether the value is managed exclusively by the owning authority.
+  ///   - writeOnly: Indicates whether the value is present when retrieved from the owning authority.
+  ///   - examples: A list of example values.
+  ///   - enum: A list of allowed values.
+  ///   - const: The only allowed value.
+  ///   - allOf: A list of schemas in which the value must match all of them.
+  ///   - anyOf: A list of schemas in which the value must match at least one of them.
+  ///   - oneOf: A list of schemas in which the value must match exactly one of them.
+  ///   - not: A schema that the value must not match.
+  ///   - if: A schema to use for control flow.
+  ///   - then: A schema to match against if a value successfully matches against ``Object/if``.
+  ///   - else: A schema to match against if a value fails to match against ``Object/if``.
+  ///   - format: A string containing information for validating values not confined with the JSON Schema specification.
+  public static func null(
+    title: String? = nil,
+    description: String? = nil,
+    `default`: Value? = nil,
+    readOnly: Bool? = nil,
+    writeOnly: Bool? = nil,
+    examples: [Value]? = nil,
+    `enum`: [Value]? = nil,
+    const: Value? = nil,
+    allOf: [JSONSchema]? = nil,
+    anyOf: [JSONSchema]? = nil,
+    oneOf: [JSONSchema]? = nil,
+    not: JSONSchema? = nil,
+    `if`: JSONSchema? = nil,
+    then: JSONSchema? = nil,
+    `else`: JSONSchema? = nil,
+    format: String? = nil
+  ) -> Self {
+    .typed(
+      title: title,
+      description: description,
+      valueSchema: .null,
+      default: `default`,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      examples: examples,
+      enum: `enum`,
+      const: const,
+      allOf: allOf,
+      anyOf: anyOf,
+      oneOf: oneOf,
+      not: not,
+      if: `if`,
+      then: then,
+      else: `else`,
+      format: format
+    )
+  }
+
+  /// Creates a boolean-specific object schema.
+  ///
+  /// - Parameters:
+  ///   - title: The title of the schema.
+  ///   - description: The description of the schema.
+  ///   - default: The default value of the schema.
+  ///   - readOnly: Indicates whether the value is managed exclusively by the owning authority.
+  ///   - writeOnly: Indicates whether the value is present when retrieved from the owning authority.
+  ///   - examples: A list of example values.
+  ///   - enum: A list of allowed values.
+  ///   - const: The only allowed value.
+  ///   - allOf: A list of schemas in which the value must match all of them.
+  ///   - anyOf: A list of schemas in which the value must match at least one of them.
+  ///   - oneOf: A list of schemas in which the value must match exactly one of them.
+  ///   - not: A schema that the value must not match.
+  ///   - if: A schema to use for control flow.
+  ///   - then: A schema to match against if a value successfully matches against ``Object/if``.
+  ///   - else: A schema to match against if a value fails to match against ``Object/if``.
+  ///   - format: A string containing information for validating values not confined with the JSON Schema specification.
+  public static func bool(
+    title: String? = nil,
+    description: String? = nil,
+    `default`: Value? = nil,
+    readOnly: Bool? = nil,
+    writeOnly: Bool? = nil,
+    examples: [Value]? = nil,
+    `enum`: [Value]? = nil,
+    const: Value? = nil,
+    allOf: [JSONSchema]? = nil,
+    anyOf: [JSONSchema]? = nil,
+    oneOf: [JSONSchema]? = nil,
+    not: JSONSchema? = nil,
+    `if`: JSONSchema? = nil,
+    then: JSONSchema? = nil,
+    `else`: JSONSchema? = nil,
+    format: String? = nil
+  ) -> Self {
+    .typed(
+      title: title,
+      description: description,
+      valueSchema: .boolean,
+      default: `default`,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      examples: examples,
+      enum: `enum`,
+      const: const,
+      allOf: allOf,
+      anyOf: anyOf,
+      oneOf: oneOf,
+      not: not,
+      if: `if`,
+      then: then,
+      else: `else`,
+      format: format
+    )
+  }
+
+  /// Creates a union-specific object schema.
+  ///
+  /// - Parameters:
+  ///   - title: The title of the schema.
+  ///   - description: The description of the schema.
+  ///   - string: String-specific constraints included in the union.
+  ///   - bool: Whether the union includes the boolean type.
+  ///   - number: Number-specific constraints included in the union.
+  ///   - integer: Integer-specific constraints included in the union.
+  ///   - array: Array-specific constraints included in the union.
+  ///   - object: Object-specific constraints included in the union.
+  ///   - null: Whether the union includes the null type.
+  ///   - default: The default value of the schema.
+  ///   - readOnly: Indicates whether the value is managed exclusively by the owning authority.
+  ///   - writeOnly: Indicates whether the value is present when retrieved from the owning authority.
+  ///   - examples: A list of example values.
+  ///   - enum: A list of allowed values.
+  ///   - const: The only allowed value.
+  ///   - allOf: A list of schemas in which the value must match all of them.
+  ///   - anyOf: A list of schemas in which the value must match at least one of them.
+  ///   - oneOf: A list of schemas in which the value must match exactly one of them.
+  ///   - not: A schema that the value must not match.
+  ///   - if: A schema to use for control flow.
+  ///   - then: A schema to match against if a value successfully matches against ``Object/if``.
+  ///   - else: A schema to match against if a value fails to match against ``Object/if``.
+  ///   - format: A string containing information for validating values not confined with the JSON Schema specification.
+  public static func union(
+    title: String? = nil,
+    description: String? = nil,
+    string: ValueSchema.String? = nil,
+    bool: Bool = false,
+    number: ValueSchema.Number? = nil,
+    integer: ValueSchema.Integer? = nil,
+    array: ValueSchema.Array? = nil,
+    object: ValueSchema.Object? = nil,
+    null: Bool = false,
+    `default`: Value? = nil,
+    readOnly: Bool? = nil,
+    writeOnly: Bool? = nil,
+    examples: [Value]? = nil,
+    `enum`: [Value]? = nil,
+    const: Value? = nil,
+    allOf: [JSONSchema]? = nil,
+    anyOf: [JSONSchema]? = nil,
+    oneOf: [JSONSchema]? = nil,
+    not: JSONSchema? = nil,
+    `if`: JSONSchema? = nil,
+    then: JSONSchema? = nil,
+    `else`: JSONSchema? = nil,
+    format: String? = nil
+  ) -> Self {
+    .typed(
+      title: title,
+      description: description,
+      valueSchema: .union(
+        string: string,
+        isBoolean: bool,
+        array: array,
+        object: object,
+        number: number,
+        integer: integer,
+        isNullable: null
+      ),
+      default: `default`,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      examples: examples,
+      enum: `enum`,
+      const: const,
+      allOf: allOf,
+      anyOf: anyOf,
+      oneOf: oneOf,
+      not: not,
+      if: `if`,
+      then: then,
+      else: `else`,
+      format: format
+    )
+  }
 }
 
 // MARK: - ExpressibleByBooleanLiteral

--- a/Tests/CactusTests/JSONSchemaTests/JSONSchema+ValidationTests.swift
+++ b/Tests/CactusTests/JSONSchemaTests/JSONSchema+ValidationTests.swift
@@ -87,7 +87,7 @@ struct `JSONSchemaValidation tests` {
     value: JSONSchema.Value
   ) {
     expectContainsFailureReason(
-      .object(valueSchema: .boolean),
+      .bool(),
       value,
       .typeMismatch(expected: .boolean)
     )
@@ -241,7 +241,7 @@ struct `JSONSchemaValidation tests` {
 
   @Test
   func `Boolean Value Valid When Type Is Boolean`() {
-    let schema = JSONSchema.object(valueSchema: .boolean)
+    let schema = JSONSchema.bool()
     expectValidates(schema, true)
     expectValidates(schema, false)
   }
@@ -381,7 +381,7 @@ struct `JSONSchemaValidation tests` {
   func `Array Allows Additional Items According To The Specified Schema`() {
     let item1Schema = JSONSchema.object(valueSchema: .number())
     let item2Schema = JSONSchema.object(valueSchema: .string())
-    let additionalSchema = JSONSchema.object(valueSchema: .boolean)
+    let additionalSchema = JSONSchema.bool()
     let schema = JSONSchema.object(
       valueSchema: .array(
         items: .itemsSchemas([item1Schema, item2Schema]),
@@ -493,7 +493,7 @@ struct `JSONSchemaValidation tests` {
   func `Object Ensures That All Additional Properties Are Validated By Schema`() {
     let p1Schema = JSONSchema.object(valueSchema: .string())
     let p2Schema = JSONSchema.object(valueSchema: .number())
-    let additionalSchema = JSONSchema.object(valueSchema: .boolean)
+    let additionalSchema = JSONSchema.bool()
     let schema = JSONSchema.object(
       valueSchema: .object(
         properties: ["a": p1Schema, "b": p2Schema],
@@ -673,17 +673,17 @@ struct `JSONSchemaValidation tests` {
     let schema = JSONSchema.object(
       valueSchema: .object(
         properties: [
-          "p1": .object(valueSchema: .string()),
+          "p1": .string(),
           "p2": .object(
             valueSchema: .object(
               properties: [
-                "p3": .object(valueSchema: .number()),
-                "p4": .object(valueSchema: .boolean)
+                "p3": .number(),
+                "p4": .bool()
               ],
               required: ["p3", "p4"]
             )
           ),
-          "p5": .object(valueSchema: .array(items: .schemaForAll(.object(valueSchema: .string()))))
+          "p5": .array(items: .schemaForAll(.string()))
         ]
       )
     )

--- a/Tests/CactusTests/LanguageModelTests/CactusLanguageModelTests.swift
+++ b/Tests/CactusTests/LanguageModelTests/CactusLanguageModelTests.swift
@@ -442,16 +442,14 @@ final class CactusLanguageModelGenerationSnapshotTests: XCTestCase {
           name: "get_weather",
           description: "Get the weather in a given location",
           parameters: .object(
-            valueSchema: .object(
-              properties: [
-                "location": .object(
-                  description: "City name",
-                  valueSchema: .string(minLength: 1),
-                  examples: ["San Francisco"]
-                )
-              ],
-              required: ["location"]
-            )
+            properties: [
+              "location": .string(
+                description: "City name",
+                minLength: 1,
+                examples: ["San Francisco"]
+              )
+            ],
+            required: ["location"]
           )
         )
       ]
@@ -478,33 +476,29 @@ final class CactusLanguageModelGenerationSnapshotTests: XCTestCase {
           name: "get_weather",
           description: "Get the weather in a given location",
           parameters: .object(
-            valueSchema: .object(
-              properties: [
-                "location": .object(
-                  description: "City name",
-                  valueSchema: .string(minLength: 1),
-                  examples: ["San Francisco"]
-                ),
-                "units": .object(valueSchema: .string(), enum: ["celsius", "farenheit"])
-              ],
-              required: ["location"]
-            )
+            properties: [
+              "location": .string(
+                description: "City name",
+                minLength: 1,
+                examples: ["San Francisco"]
+              ),
+              "units": .string(enum: ["celsius", "farenheit"])
+            ],
+            required: ["location"]
           )
         ),
         CactusLanguageModel.FunctionDefinition(
           name: "get_population",
           description: "Gets the population of a given city",
           parameters: .object(
-            valueSchema: .object(
-              properties: [
-                "location": .object(
-                  description: "City name",
-                  valueSchema: .string(minLength: 1),
-                  examples: ["San Francisco"]
-                )
-              ],
-              required: ["location"]
-            )
+            properties: [
+              "location": .string(
+                description: "City name",
+                minLength: 1,
+                examples: ["San Francisco"]
+              )
+            ],
+            required: ["location"]
           )
         )
       ]


### PR DESCRIPTION
When looking at:

```
.object(
  description: "City name, eg. 'San Francisco'",
  valueSchema: .string(minLength: 1),
  examples: ["San Francisco"]
)
```

It would be hard to tell that the schema is for a string. So this adds some conevenience initializers on `JSONSchema` to make that more clear:

```
.string(
  description: "City name, eg. 'San Francisco'",
  minLength: 1,
  examples: ["San Francisco"]
)
```