### PR TITLE
`@JSONSchemaKey` Macro

### DIFF
--- a/Sources/Cactus/Macros.swift
+++ b/Sources/Cactus/Macros.swift
@@ -12,6 +12,11 @@ public macro JSONSchema() = #externalMacro(module: "CactusMacros", type: "JSONSc
 public macro JSONSchemaIgnored() =
   #externalMacro(module: "CactusMacros", type: "JSONSchemaIgnoredMacro")
 
+/// Overrides a stored property's synthesized key in the generated ``JSONSchema`` object.
+@attached(peer)
+public macro JSONSchemaKey(_ key: Swift.String) =
+  #externalMacro(module: "CactusMacros", type: "JSONSchemaKeyMacro")
+
 /// Overrides schema synthesis for a string property using semantic validation constraints.
 @attached(peer)
 public macro JSONStringSchema(

--- a/Sources/CactusMacros/JSONSchemaKeyMacro.swift
+++ b/Sources/CactusMacros/JSONSchemaKeyMacro.swift
@@ -1,0 +1,12 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum JSONSchemaKeyMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    []
+  }
+}

--- a/Sources/CactusMacros/Plugin.swift
+++ b/Sources/CactusMacros/Plugin.swift
@@ -6,6 +6,7 @@ struct CactusMacrosPlugin: CompilerPlugin {
   let providingMacros: [any Macro.Type] = [
     JSONSchemaMacro.self,
     JSONSchemaIgnoredMacro.self,
+    JSONSchemaKeyMacro.self,
     JSONStringSchemaMacro.self,
     JSONNumberSchemaMacro.self,
     JSONIntegerSchemaMacro.self,

--- a/Tests/CactusMacrosTests/BaseTestSuite.swift
+++ b/Tests/CactusMacrosTests/BaseTestSuite.swift
@@ -10,6 +10,7 @@ import Testing
     [
       "JSONSchema": JSONSchemaMacro.self,
       "JSONSchemaIgnored": JSONSchemaIgnoredMacro.self,
+      "JSONSchemaKey": JSONSchemaKeyMacro.self,
       "JSONStringSchema": JSONStringSchemaMacro.self,
       "JSONNumberSchema": JSONNumberSchemaMacro.self,
       "JSONIntegerSchema": JSONIntegerSchemaMacro.self,


### PR DESCRIPTION
Adds a new `@JSONSchemaKey` macro to allow renaming property name in the generated `jsonSchema`.