### PR TITLE
Support message name Property

### DIFF
--- a/Sources/CactusCore/Agent/CactusAgentSession.swift
+++ b/Sources/CactusCore/Agent/CactusAgentSession.swift
@@ -985,12 +985,9 @@ extension CactusAgentSession {
     completionEntries: inout [CactusCompletionEntry]
   ) throws {
     for functionReturn in functionReturns {
-      let content = try self.functionOutputPayload(
-        name: functionReturn.name,
-        content: functionReturn.content
-      )
+      let components = try functionReturn.content.messageComponents()
       self.appendTranscriptEntry(
-        CactusModel.Message(role: role, content: content),
+        .tool(components.text, name: functionReturn.name),
         metrics: nil,
         completionEntries: &completionEntries
       )
@@ -1012,20 +1009,6 @@ extension CactusAgentSession {
       return []
     }
     return Array(messages.dropFirst(originalMessagesCount))
-  }
-
-  private func functionOutputPayload(
-    name: String,
-    content: CactusPromptContent
-  ) throws -> String {
-    struct Payload: Encodable {
-      let name: String
-      let content: String
-    }
-
-    let components = try content.messageComponents()
-    let data = try JSONEncoder().encode(Payload(name: name, content: components.text))
-    return String(decoding: data, as: UTF8.self)
   }
 }
 

--- a/Sources/CactusCore/Model/CactusModel+ChatMessage.swift
+++ b/Sources/CactusCore/Model/CactusModel+ChatMessage.swift
@@ -38,6 +38,30 @@ extension CactusModel {
       Self(role: .assistant, content: content)
     }
 
+    /// Creates a tool message.
+    ///
+    /// Use this initializer when providing tool output to the model.
+    ///
+    /// - Parameters:
+    ///   - content: The tool output content.
+    ///   - name: The name of the tool that produced this output.
+    /// - Returns: A ``CactusModel/Message``.
+    public static func tool(_ content: String, name: String) -> Self {
+      Self(role: .tool, content: content, name: name)
+    }
+
+    /// Creates a function message.
+    ///
+    /// This is an alias for ``tool(_:name:)``.
+    ///
+    /// - Parameters:
+    ///   - content: The function output content.
+    ///   - name: The name of the function that produced this output.
+    /// - Returns: A ``CactusModel/Message``.
+    public static func function(_ content: String, name: String) -> Self {
+      Self(role: .function, content: content, name: name)
+    }
+
     /// The ``Role`` of the message.
     public var role: Role
 
@@ -47,16 +71,28 @@ extension CactusModel {
     /// An array of `URL`s to locally stored images.
     public var images: [URL]?
 
+    /// The name of the tool or function that produced this message.
+    ///
+    /// This is used for messages with the ``Role/tool`` or ``Role/function`` role.
+    public var name: String?
+
     /// Creates a message.
     ///
     /// - Parameters:
     ///   - role: The ``Role`` of the message.
     ///   - content: The message content.
     ///   - images: An array of `URL`s to locally stored images.
-    public init(role: Role, content: String, images: [URL]? = nil) {
+    ///   - name: The name of the tool or function that produced this message.
+    public init(
+      role: Role,
+      content: String,
+      images: [URL]? = nil,
+      name: String? = nil
+    ) {
       self.role = role
       self.content = content
       self.images = images
+      self.name = name
     }
   }
 }

--- a/Sources/CactusCore/Model/CactusModel.swift
+++ b/Sources/CactusCore/Model/CactusModel.swift
@@ -845,11 +845,13 @@ extension CactusModel {
   private struct FFIMessage: Codable {
     let role: Message.Role
     let content: String
+    let name: String?
     let images: [String]?
 
     init(message: Message) {
       self.role = message.role
       self.content = message.content
+      self.name = message.name
       self.images = message.images?.map(\.nativePath)
     }
   }

--- a/Tests/CactusTests/AgentTests/CactusAgentSessionTests.swift
+++ b/Tests/CactusTests/AgentTests/CactusAgentSessionTests.swift
@@ -253,7 +253,7 @@ struct `CactusAgentSession tests` {
       )
 
       let completion = try await session.respond(
-        to: CactusUserMessage(forceFunctions: true) {
+        to: CactusUserMessage {
           "Use the get_fact tool for both 'cactus' and 'swift', then summarize both facts."
         }
       )
@@ -390,18 +390,18 @@ struct `CactusAgentSession tests` {
 
       @JSONSchema
       struct Input: Codable, Sendable {
-        let topic: String
+        let subject: String
       }
 
       let name = "get_fact"
       let description = "Returns a short fact for a topic"
 
       func invoke(input: sending Input) async throws -> sending String {
-        switch input.topic.lowercased() {
+        switch input.subject.lowercased() {
         case "cactus": "Cacti store water in thick stems to survive arid climates."
         case "swift":
           "Swift is a type-safe language that emphasizes expressive syntax and performance."
-        default: "No fact available for \(input.topic)."
+        default: "No fact available for \(input.subject)."
         }
       }
     }

--- a/Tests/CactusTests/AgentTests/__Snapshots__/CactusAgentSessionTests/Tool-Call-Respond-Returns-Completion-Entries-And-Metrics-Dump-Snapshot.1.txt
+++ b/Tests/CactusTests/AgentTests/__Snapshots__/CactusAgentSessionTests/Tool-Call-Respond-Returns-Completion-Entries-And-Metrics-Dump-Snapshot.1.txt
@@ -1,37 +1,89 @@
-▿ 2 elements
+▿ 5 elements
   ▿ CactusCompletionEntry
     - metrics: Optional<CactusGenerationMetrics>.none
     ▿ transcriptEntry: Element
       ▿ id: CactusGenerationID
-        - rawValue: A924C5E3-260B-4033-AF98-ACD9262FF79A
+        - rawValue: 6197FC55-26D0-464A-A4AA-ABB07995A444
       ▿ message: Message
         - content: "Use the get_fact tool for both \'cactus\' and \'swift\', then summarize both facts."
         ▿ images: Optional<Array<URL>>
           - some: 0 elements
+        - name: Optional<String>.none
         ▿ role: Role
           - rawValue: "user"
   ▿ CactusCompletionEntry
     ▿ metrics: Optional<CactusGenerationMetrics>
       ▿ some: CactusGenerationMetrics
-        - confidence: 0.9323
-        - decodeTokens: 49
-        - decodeTps: 34.62
+        - confidence: 0.9936
+        - decodeTokens: 22
+        - decodeTps: 35.55
         - didHandoffToCloud: false
-        ▿ durationToFirstToken: 1.24326 seconds
-          - _low: 1243259999999999991
+        ▿ durationToFirstToken: 1.45685 seconds
+          - _low: 1456849999999999909
           - _high: 0
-        - prefillTokens: 119
-        - prefillTps: 95.72
-        - ramUsageMb: 992.64
-        ▿ totalDuration: 2.62955 seconds
-          - _low: 2629550000000000182
+        - prefillTokens: 142
+        - prefillTps: 97.47
+        - ramUsageMb: 620.99
+        ▿ totalDuration: 2.04756 seconds
+          - _low: 2047559999999999945
           - _high: 0
-        - totalTokens: 168
+        - totalTokens: 164
     ▿ transcriptEntry: Element
       ▿ id: CactusGenerationID
-        - rawValue: BD540357-A81E-4424-B430-3983324CFBF0
+        - rawValue: A627AB80-633C-4B86-9FA4-597350F5659A
       ▿ message: Message
-        - content: "To provide the requested information, I need to know the specific topic for which you\'d like a fact. Could you please specify what topic or subject area (e.g., \"space exploration,\" \"ancient civilizations\")) your question relates to?"
+        - content: "<|tool_call_start|>[get_fact(subject=\"cactus\"), get_fact(subject=\"swift\")]<|tool_call_end|>"
         - images: Optional<Array<URL>>.none
+        - name: Optional<String>.none
+        ▿ role: Role
+          - rawValue: "assistant"
+  ▿ CactusCompletionEntry
+    - metrics: Optional<CactusGenerationMetrics>.none
+    ▿ transcriptEntry: Element
+      ▿ id: CactusGenerationID
+        - rawValue: C32F4834-1A21-4387-8054-B8A3DAA74498
+      ▿ message: Message
+        - content: "Cacti store water in thick stems to survive arid climates."
+        - images: Optional<Array<URL>>.none
+        ▿ name: Optional<String>
+          - some: "get_fact"
+        ▿ role: Role
+          - rawValue: "tool"
+  ▿ CactusCompletionEntry
+    - metrics: Optional<CactusGenerationMetrics>.none
+    ▿ transcriptEntry: Element
+      ▿ id: CactusGenerationID
+        - rawValue: 33DE8082-83CA-478A-B69B-203F5CA1FCCA
+      ▿ message: Message
+        - content: "Swift is a type-safe language that emphasizes expressive syntax and performance."
+        - images: Optional<Array<URL>>.none
+        ▿ name: Optional<String>
+          - some: "get_fact"
+        ▿ role: Role
+          - rawValue: "tool"
+  ▿ CactusCompletionEntry
+    ▿ metrics: Optional<CactusGenerationMetrics>
+      ▿ some: CactusGenerationMetrics
+        - confidence: 0.9434
+        - decodeTokens: 37
+        - decodeTps: 33.26
+        - didHandoffToCloud: false
+        ▿ durationToFirstToken: 2.1128400000000003 seconds
+          - _low: 2112840000000000146
+          - _high: 0
+        - prefillTokens: 211
+        - prefillTps: 99.87
+        - ramUsageMb: 925.82
+        ▿ totalDuration: 3.1951 seconds
+          - _low: 3195099999999999909
+          - _high: 0
+        - totalTokens: 248
+    ▿ transcriptEntry: Element
+      ▿ id: CactusGenerationID
+        - rawValue: 490A01B4-BA2D-4020-878B-B3A80DBC8F76
+      ▿ message: Message
+        - content: "The cactus stores water in its thick stems to thrive in dry environments. Swift is a type-safe language known for its expressive syntax and high performance, often used for iOS development."
+        - images: Optional<Array<URL>>.none
+        - name: Optional<String>.none
         ▿ role: Role
           - rawValue: "assistant"


### PR DESCRIPTION
The engine now supports a `name` property to directly reference the name of the invoked function. Let's take advantage of it.